### PR TITLE
CDPE-3018 adds check for ca_cert_file

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -105,10 +105,12 @@ class CD4PEClient < Object
     if @http_config[:scheme] == 'https'
       connection.use_ssl = true
       connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      store = OpenSSL::X509::Store.new
-      store.set_default_paths
-      store.add_file(@ca_cert_file)
-      connection.cert_store = store
+      if !@ca_cert_file.nil?
+        store = OpenSSL::X509::Store.new
+        store.set_default_paths
+        store.add_file(@ca_cert_file)
+        connection.cert_store = store
+      end
     end
 
     connection.read_timeout = 60 # 1 minute

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -140,7 +140,7 @@ class CD4PEClient < Object
           raise "cd4pe_client#make_request called with invalid request type #{type}"
         end
       rescue SocketError => e
-        raise "Could not connect to the CD4PE service at #{service_url}: #{e.inspect}", e.backtrace
+        raise "Could not connect to the CD4PE service at #{api_url}: #{e.inspect}", e.backtrace
       end
 
       case response
@@ -154,10 +154,10 @@ class CD4PEClient < Object
         raise "#{response.code} #{response.body}"
       when Net::HTTPInternalServerError
         if attempts < max_attempts # rubocop:disable Style/GuardClause
-          @logger.log("Received #{response} error from #{service_url}, attempting to retry. (Attempt #{attempts} of #{max_attempts})")
+          @logger.log("Received #{response} error from #{api_url}, attempting to retry. (Attempt #{attempts} of #{max_attempts})")
           Kernel.sleep(3)
         else
-          raise "Received #{attempts} server error responses from the CD4PE service at #{service_url}: #{response.code} #{response.body}"
+          raise "Received #{attempts} server error responses from the CD4PE service at #{api_url}: #{response.code} #{response.body}"
         end
       else
         return response


### PR DESCRIPTION
This adds a nil check for the ca_cert_file when we are deciding whether or not to create an X509 store so that if https is enabled but we don't have a cert, we don't create the store as creating the store in that scenario was causing all jobs to fail with the elegant 'system lib' error message.