### PR TITLE
CDPE-3032: Delete docker container after job run

### DIFF
--- a/spec/run_cd4pe_job_spec.rb
+++ b/spec/run_cd4pe_job_spec.rb
@@ -35,18 +35,18 @@ describe 'run_cd4pe_job' do
     end
   end
 
-  describe 'make_working_dir' do
+  describe 'make_dir' do
     it 'Makes working directory as specified.' do
       # validate dir does not exist
       test_dir = File.join(@working_dir, 'test_dir')
       expect(File.exists?(test_dir)).to be(false)
 
       # create dir and validate it exists
-      make_working_dir(test_dir)
+      make_dir(test_dir)
       expect(File.exists?(test_dir)).to be(true)
 
       # attempt to create again to validate it does not throw
-      make_working_dir(test_dir)
+      make_dir(test_dir)
     end
   end
 
@@ -154,15 +154,16 @@ describe 'run_cd4pe_job' do
   
       expect(cmd_parts[0]).to eq('docker')
       expect(cmd_parts[1]).to eq('run')
-      expect(cmd_parts[2]).to eq(arg1)
-      expect(cmd_parts[3]).to eq(arg2)
-      expect(cmd_parts[4]).to eq(arg3)
-      expect(cmd_parts[5]).to eq('-v')
-      expect(cmd_parts[6].end_with?("/#{File.basename(@working_dir)}/cd4pe_job/repo:/repo\"")).to be(true)
-      expect(cmd_parts[7]).to eq('-v')
-      expect(cmd_parts[8].end_with?("/#{File.basename(@working_dir)}/cd4pe_job/jobs/unix:/cd4pe_job\"")).to be(true)
-      expect(cmd_parts[9]).to eq(test_docker_image)
-      expect(cmd_parts[10]).to eq('"/cd4pe_job/AFTER_JOB_SUCCESS"')
+      expect(cmd_parts[2]).to eq('--rm')
+      expect(cmd_parts[3]).to eq(arg1)
+      expect(cmd_parts[4]).to eq(arg2)
+      expect(cmd_parts[5]).to eq(arg3)
+      expect(cmd_parts[6]).to eq('-v')
+      expect(cmd_parts[7].end_with?("/#{File.basename(@working_dir)}/cd4pe_job/repo:/repo\"")).to be(true)
+      expect(cmd_parts[8]).to eq('-v')
+      expect(cmd_parts[9].end_with?("/#{File.basename(@working_dir)}/cd4pe_job/jobs/unix:/cd4pe_job\"")).to be(true)
+      expect(cmd_parts[10]).to eq(test_docker_image)
+      expect(cmd_parts[11]).to eq('"/cd4pe_job/AFTER_JOB_SUCCESS"')
     end
   end
 end

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -314,7 +314,7 @@ class CD4PEJobRunner < Object
     repo_volume_mount = "\"#{@local_repo_dir}:/repo\""
     scripts_volume_mount = "\"#{@local_jobs_dir}:/cd4pe_job\""
     docker_bash_script = "\"/cd4pe_job/#{manifest_type}\""
-    "docker run #{@docker_run_args} -v #{repo_volume_mount} -v #{scripts_volume_mount} #{@docker_image} #{docker_bash_script}"
+    "docker run --rm #{@docker_run_args} -v #{repo_volume_mount} -v #{scripts_volume_mount} #{@docker_image} #{docker_bash_script}"
   end
   
   def run_with_docker(manifest_type)


### PR DESCRIPTION
With this change, we add the --rm flag to our docker run command to
ensure that the docker container gets removed after each docker-based
job  execution.

I also fixed a broken unit test related to 'make_dir'.

Test executed:
I ran 4 jobs with the old code, and then ran a `sudo docker ps -a` on the puppet agent that ran the job. All 4 containers were still mounted. 

I implemented the change, and ran the same test, monitoring the state of `sudo docker ps -a` during the job runs. The containers were spun up, and then removed.
<img width="1073" alt="Screen Shot 2020-03-05 at 8 16 19 AM" src="https://user-images.githubusercontent.com/8687939/76001386-e3adcb80-5eb9-11ea-90f6-6de6991e7f9f.png">
