### PR TITLE
CDPE-3069: Pass URI object to HTTP requests

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -119,6 +119,7 @@ class CD4PEClient < Object
       'Content-Type' => 'application/json',
       'Authorization' => "Bearer token #{@job_token}",
     }
+    uri = URI.parse(api_url)
 
     max_attempts = 3
     attempts = 0
@@ -129,13 +130,13 @@ class CD4PEClient < Object
         @logger.log("cd4pe_client: requesting #{type} #{api_url}")
         case type
         when :delete
-          response = connection.delete(api_url, headers)
+          response = connection.delete(uri, headers)
         when :get
-          response = connection.get(api_url, headers)
+          response = connection.get(uri, headers)
         when :post
-          response = connection.post(api_url, payload, headers)
+          response = connection.post(uri, payload, headers)
         when :put
-          response = connection.put(api_url, payload, headers)
+          response = connection.put(uri, payload, headers)
         else
           raise "cd4pe_client#make_request called with invalid request type #{type}"
         end


### PR DESCRIPTION
This ensures the path and query parameters are correctly formatted. Previously the path being passed included `scheme://host:port`, which is considered an invalid path by some routing systems (such as Envoy).

Signed-off-by: Michael Smith <michael.smith@puppet.com>