### PR TITLE
CDPE-3177: Set HOME and REPO_DIR env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # cd4pe_jobs
 
-This module exists for Continuous Delivery for Puppet Enterprise to run jobs on Puppet Agents via Bolt. It contains a single task to do this and works with both *nix and Windows.
+This module exists for Continuous Delivery for Puppet Enterprise to run jobs on Puppet Agents via Bolt. It contains a single task to do this and works with both \*nix and Windows.
+
+To run tests (from root of repo):
+`bundle exec rspec spec`

--- a/spec/run_cd4pe_job_spec.rb
+++ b/spec/run_cd4pe_job_spec.rb
@@ -136,6 +136,13 @@ describe 'run_cd4pe_job' do
   
       expect(job_helper.docker_run_args).to eq("#{arg1} #{arg2} #{arg3}")
     end
+
+    it 'Sets the HOME and REPO_DIR env vars' do
+      job_helper = CD4PEJobRunner.new(working_dir: @working_dir, job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, logger: @logger)
+
+      expect(ENV['HOME'] != nil).to be(true)
+      expect(ENV['REPO_DIR']).to eq("#{@working_dir}/cd4pe_job/repo")
+    end
   end
 
   describe 'cd4pe_job_helper::get_docker_run_cmd' do

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -8,6 +8,7 @@ require 'net/http'
 require 'base64'
 require 'facter'
 require 'date'
+require 'etc'
 
 class Logger < Object
   # Class to track logs + timestamps. To be returned as part of the Bolt log output
@@ -207,10 +208,14 @@ class CD4PEJobRunner < Object
   end
 
   def set_home_env_var
+    # when the puppet orchestrator runs a Bolt task, it does so as a user without $HOME set.
+    # We need to ensure $HOME is set so jobs that rely on this env var can succeed.
     if (@windows_job)
+      # if windows, we can rely on powershell
       ENV['HOME'] = run_system_cmd("powershell (Resolve-Path ~")[:message]
     else
-      ENV['HOME'] = Dir.home
+      # if not windows, we must use a ruby solution to ensure cross-system compatibility.
+      ENV['HOME'] = Etc.getpwuid.dir
     end
   end
 

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -200,9 +200,23 @@ class CD4PEJobRunner < Object
         file.write(ca_cert)
       end
     end
+
+    set_home_env_var
+    set_repo_dir_env_var
     
   end
 
+  def set_home_env_var
+    if (@windows_job)
+      ENV['HOME'] = run_system_cmd("powershell (Resolve-Path ~")[:message]
+    else
+      ENV['HOME'] = Dir.home
+    end
+  end
+
+  def set_repo_dir_env_var
+    ENV['REPO_DIR'] = @local_repo_dir
+  end
 
   def get_job_script_and_control_repo
     @logger.log("Downloading job scripts and control repo from CD4PE.")


### PR DESCRIPTION
Prior to this change, jobs run via orchestrator on a puppet agent would
not have their $HOME env var set, causing problems for many common
tasks run inside jobs, such as `bundle pdk install`. We also had no way
for the writer of the cd4pe job script to reference the control repo
they wished to run tests on, forcing them to use a relative path in
their job script to locate the repos dir.

With this change, we set the $HOME var on the puppet agent before
executing the job script so it is accessible for the duration of the
job, and the $REPO_DIR var to the parent of the control repo so the
cd4pe job script writer can reliably access the control repo.

**Testing:**
I updated my PE master with this code, created two test machines: Centos and Windows, and ran jobs on both, ensuring I could properly access both the $HOME and $REPO_DIR env vars.