### PR TITLE
CDPE-3250 Handle long Puppet agent job logs

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -268,7 +268,13 @@ class CD4PEJobRunner < Object
     }
 
     client = CD4PEClient.new(web_ui_endpoint: api_endpoint, job_token: @job_token, ca_cert_file: @ca_cert_file, logger: @logger)
-    response = client.make_request(:post, api_endpoint, payload.to_json)
+
+    begin
+      response = client.make_request(:post, api_endpoint, payload.to_json)
+    rescue => e
+      @logger.log("Problem sending logs to CD4PE. Printing output to std output. #{e.message}") # test by hacking endpoint
+      puts output.to_json
+    end
   end
 
   def run_job


### PR DESCRIPTION
With this change, we send the detailed log output of Puppet
agent jobs to a new endpoint in CD4PE.
    
Prior to this commit, if a Puppet agent job produced too many log
entries, the Orchestrator would crash and the job would fail.
See detail from ticket `ORCH-2255`...
```
Any user using bolt with PXP will likely come across this. Users
will not expect there to be limitations when uploading a 5Mb file
or run a 1500 line script, both if which will cause orchestrator/PXP
to fall over completely. Users will expect this to work as it
works fine over SSH or WinRM.
```