### PR TITLE
CDPE-3390: Fix jobs hung by large stdout/err

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -374,11 +374,9 @@ class CD4PEJobRunner < Object
     exit_code = 0
 
     @logger.log("Executing system command: #{cmd}")
-    Open3.popen2e(cmd) do |stdin, stdout_stderr, wait_thr|
-      exit_code = wait_thr.value.exitstatus
-      output = stdout_stderr.read
-    end
-  
+    output, wait_thr = Open3.capture2e(cmd)
+    exit_code = wait_thr.exitstatus
+
     { :exit_code => exit_code, :message => output }
   end
 


### PR DESCRIPTION
Prior to this change, there existed a bug in which executing a job with
a large stdout/stderr would cause a job to hang. This was due to the
fact that we were using Open3.popen2e, a function that exists to
execute system commands, and provide the caller a way to interact with
stdout/etderr on a line-by-line basis. popen2e, however, also requires
the caller to create another thread for safely tracking output. If the
second thread is not created/maintained, popen2e will hang on a large
stdout/stderr.

With this change, we replace our usage of popen2e with the higher-level
function, `capture2e`, which exists to capture stdout/stderr without the
caller having to manage multiple threads.

Reference:
https://docs.ruby-lang.org/en/2.5.0/Open3.html