### PR TITLE
CDPE-3334: make module backwards compatible with CD4PE 3.9.3 and lower

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -272,11 +272,11 @@ class CD4PEJobRunner < Object
     begin
       response = client.make_request(:post, api_endpoint, payload.to_json)
       if (response.code != 200)
-        @logger.log("Sending logs directly to CD4PE not supported in CD4PE version < 3.10.0. Printing logs to std out.")
+        @logger.log("Unable to send logs directly to CD4PE. Printing logs to std out.")
         puts output.to_json
       end
     rescue => e
-      @logger.log("Problem sending logs to CD4PE. Printing logs to std out. #{e.message}")
+      @logger.log("Problem sending logs to CD4PE. Printing logs to std out. Error message: #{e.message}")
       puts output.to_json
     end
   end

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -270,7 +270,11 @@ class CD4PEJobRunner < Object
     client = CD4PEClient.new(web_ui_endpoint: api_endpoint, job_token: @job_token, ca_cert_file: @ca_cert_file, logger: @logger)
 
     begin
-      client.make_request(:post, api_endpoint, payload.to_json)
+      response = client.make_request(:post, api_endpoint, payload.to_json)
+      if (response.code != 200)
+        @logger.log("Sending logs directly to CD4PE not supported in CD4PE version < 3.10.0. Printing logs to std out.")
+        puts output.to_json
+      end
     rescue => e
       @logger.log("Problem sending logs to CD4PE. Printing logs to std out. #{e.message}")
       puts output.to_json


### PR DESCRIPTION
Prior to this commit, we implemented a new feature to send CD4PE job
logs directly from the puppet agent to a new CD4PE endpoint to avoid
problems with the Puppet orchestrator. However, we failed to make these
changes backwards compatible, such that customers consuming the CD4PE
jobs module would see failed jobs if they failed to update CD4PE to
3.10.0.

With this change, we add logic to handle this case, and fallback to the
old behavior if the customer is using a version of CD4PE 3.9.3 or lower.

**3.10.0 and higher logs:**
```
2020-06-08 22:09:57 UTC: Job instance 37 run complete.
2020-06-08 22:09:57 UTC: Sending logs to CD4PE.
2020-06-08 22:09:59 UTC: Job completed successfully!
```

**3.9.3 or lower logs:**
```
2020-06-08 22:48:18 UTC: Job instance 313 run complete.
2020-06-08 22:48:18 UTC: Sending logs to CD4PE.
2020-06-08 22:48:18 UTC: cd4pe_client: requesting post http://cbb0ff7dc477.ngrok.io/test-workspace1/ajax
2020-06-08 22:48:18 UTC: Sending logs directly to CD4PE not supported in CD4PE version < 3.10.0. Printing logs to std out.
2020-06-08 22:48:19 UTC: Job completed successfully!
```

**Logs if any other error is hit when submitting:**
```
2020-06-08 22:45:24 UTC: Sending logs to CD4PE.
2020-06-08 22:45:24 UTC: cd4pe_client: requesting post http://cbb0ff7dc477.ngrok.io/test-workspace1/ajax
2020-06-08 22:45:24 UTC: Problem sending logs to CD4PE. Printing logs to std out. undefined local variable or method `reponse' for #<CD4PEJobRunner:0x00000000028a5fa0>
Did you mean?  response
2020-06-08 22:45:25 UTC: Job completed successfully!
```