### PR TITLE
CDPE-3457: fix res code handling when saving logs

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -271,8 +271,8 @@ class CD4PEJobRunner < Object
 
     begin
       response = client.make_request(:post, api_endpoint, payload.to_json)
-      if (response.code != 200)
-        @logger.log("Unable to send logs directly to CD4PE. Printing logs to std out.")
+      if (response.code != '200')
+        @logger.log("Unable to send logs directly to CD4PE. Printing logs to std out. #{response.code} #{response.body}")
         puts output.to_json
       end
     rescue => e

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -271,7 +271,7 @@ class CD4PEJobRunner < Object
 
     begin
       response = client.make_request(:post, api_endpoint, payload.to_json)
-      if (response.code != '200')
+      if (!response.is_a?(Net::HTTPSuccess))
         @logger.log("Unable to send logs directly to CD4PE. Printing logs to std out. #{response.code} #{response.body}")
         puts output.to_json
       end


### PR DESCRIPTION
Prior to this change, when a cd4pe job sent logs to cd4pe, we
misinterpreted the response code, and also sent the logs to stdout.
This caused a bug where the job log would appear to have sent the logs
to cd4pe, thereby circumventing the need to send logs to stdout, but
would actually send logs to stdout on the sly, causing jobs with large
logs to hang.

With this change, we fix the response code handling to properly
interpret the response code from cd4pe.

**Testing**
Validated new code properly handles response code from cd4pe by performing and e2e test ensuring the job logs are sent to cd4pe, and NO output is sent to STDOUT.