### PR TITLE
CDPE-3033: Use http read timeout env var to override connection timeouts 

### DIFF
--- a/spec/run_cd4pe_job_spec.rb
+++ b/spec/run_cd4pe_job_spec.rb
@@ -145,20 +145,6 @@ describe 'run_cd4pe_job' do
     end
   end
 
-  describe 'cd4pe_job_helper::initialize' do
-    it 'Sets defaults to 600 http_read_timeout_seconds when unset' do
-      job_helper = CD4PEJobRunner.new(working_dir: @working_dir, job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, logger: @logger)
-
-      expect(job_helper.http_read_timeout_seconds).to eq(600)
-    end
-
-    it 'Sets http_read_timeout_seconds' do
-      expected_seconds = 100
-      job_helper = CD4PEJobRunner.new(working_dir: @working_dir, job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, http_read_timeout_seconds: expected_seconds, logger: @logger)
-      expect(job_helper.http_read_timeout_seconds).to eq(expected_seconds)
-    end
-  end
-
   describe 'cd4pe_job_helper::get_docker_run_cmd' do
     it 'Generates the correct docker run command.' do
       test_manifest_type = "AFTER_JOB_SUCCESS"

--- a/tasks/run_cd4pe_job.json
+++ b/tasks/run_cd4pe_job.json
@@ -33,11 +33,6 @@
     "base_64_ca_cert": {
       "type": "Optional[String[1]]",
       "description": "Ca cert needed to communicate with CD4PE if ssl is enabled."
-    },
-    "http_read_timeout_seconds": {
-      "type": "Optional[Integer[1]]",
-      "description": "Number of seconds to wait before timeout when performing http requests against the cd4pe_web_ui_endpoint.",
-      "default": 600
     }
   },
 

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -86,11 +86,10 @@ end
 class CD4PEClient < Object
   attr_reader :config, :owner_ajax_path
 
-  def initialize(web_ui_endpoint:, job_token:, ca_cert_file: nil, http_read_timeout_seconds:, logger:)
+  def initialize(web_ui_endpoint:, job_token:, ca_cert_file: nil, logger:)
     @web_ui_endpoint = web_ui_endpoint
     @job_token = job_token
     @ca_cert_file = ca_cert_file
-    @http_read_timeout_seconds = http_read_timeout_seconds
     @logger = logger
 
     uri = URI.parse(web_ui_endpoint)
@@ -115,7 +114,7 @@ class CD4PEClient < Object
       end
     end
 
-    connection.read_timeout = @http_read_timeout_seconds
+    connection.read_timeout = 600 # 10 minutes
 
     headers = {
       'Content-Type' => 'application/json',
@@ -129,7 +128,7 @@ class CD4PEClient < Object
     while attempts < max_attempts
       attempts += 1
       begin
-        @logger.log("cd4pe_client: requesting #{type} #{api_url} with read timeout: #{connection.read_timeout} seconds")
+        @logger.log("cd4pe_client: requesting #{type} #{api_url}")
         case type
         when :delete
           response = connection.delete(uri, headers)
@@ -170,14 +169,14 @@ end
 
 class CD4PEJobRunner < Object
   # Class for downloading, running, and logging CD4PE jobs
-  attr_reader :docker_run_args, :http_read_timeout_seconds
+  attr_reader :docker_run_args 
 
   MANIFEST_TYPE = { 
     :JOB => "JOB", 
     :AFTER_JOB_SUCCESS => "AFTER_JOB_SUCCESS", 
     :AFTER_JOB_FAILURE => "AFTER_JOB_FAILURE" }
 
-  def initialize(working_dir:, job_token:, web_ui_endpoint:, job_owner:, job_instance_id:, logger:, windows_job: false, base_64_ca_cert: nil, docker_image: nil, docker_run_args: nil, http_read_timeout_seconds: 600)
+  def initialize(working_dir:, job_token:, web_ui_endpoint:, job_owner:, job_instance_id:, logger:, windows_job: false, base_64_ca_cert: nil, docker_image: nil, docker_run_args: nil)
     @working_dir = working_dir
     @job_token = job_token
     @web_ui_endpoint = web_ui_endpoint
@@ -187,7 +186,6 @@ class CD4PEJobRunner < Object
     @docker_run_args = docker_run_args.nil? ? '' : docker_run_args.join(' ')
     @docker_based_job = !blank?(docker_image)
     @windows_job = windows_job
-    @http_read_timeout_seconds = http_read_timeout_seconds
 
     @logger = logger
 
@@ -230,7 +228,7 @@ class CD4PEJobRunner < Object
     # download payload bytes
     api_endpoint = File.join(@web_ui_endpoint, @job_owner, 'getJobScriptAndControlRepo')
     job_instance_endpoint = "#{api_endpoint}?jobInstanceId=#{@job_instance_id}"
-    client = CD4PEClient.new(web_ui_endpoint: job_instance_endpoint, job_token: @job_token, ca_cert_file: @ca_cert_file, http_read_timeout_seconds: @http_read_timeout_seconds, logger: @logger)
+    client = CD4PEClient.new(web_ui_endpoint: job_instance_endpoint, job_token: @job_token, ca_cert_file: @ca_cert_file, logger: @logger)
     response = client.make_request(:get, job_instance_endpoint)
 
     case response
@@ -269,7 +267,7 @@ class CD4PEJobRunner < Object
       },
     }
 
-    client = CD4PEClient.new(web_ui_endpoint: api_endpoint, job_token: @job_token, ca_cert_file: @ca_cert_file, http_read_timeout_seconds: @http_read_timeout_seconds, logger: @logger)
+    client = CD4PEClient.new(web_ui_endpoint: api_endpoint, job_token: @job_token, ca_cert_file: @ca_cert_file, logger: @logger)
 
     begin
       response = client.make_request(:post, api_endpoint, payload.to_json)
@@ -464,7 +462,6 @@ if __FILE__ == $0 # This block will only be invoked if this file is executed. Wi
     job_token = params['cd4pe_token']
     job_owner = params['cd4pe_job_owner']
     base_64_ca_cert = params['base_64_ca_cert']
-    http_read_timeout_seconds = params['http_read_timeout_seconds'] || 600
 
     set_job_env_vars(params)
 
@@ -473,7 +470,7 @@ if __FILE__ == $0 # This block will only be invoked if this file is executed. Wi
     @working_dir = File.join(root_job_dir, "cd4pe_job_instance_#{job_instance_id}_#{DateTime.now.strftime('%Q')}")
     make_dir(@working_dir)
 
-    job_runner = CD4PEJobRunner.new(working_dir: @working_dir, docker_image: docker_image, docker_run_args: docker_run_args, job_token: job_token, web_ui_endpoint: web_ui_endpoint, job_owner: job_owner, job_instance_id: job_instance_id, base_64_ca_cert: base_64_ca_cert, windows_job: windows_job, http_read_timeout_seconds: http_read_timeout_seconds, logger: @logger)
+    job_runner = CD4PEJobRunner.new(working_dir: @working_dir, docker_image: docker_image, docker_run_args: docker_run_args, job_token: job_token, web_ui_endpoint: web_ui_endpoint, job_owner: job_owner, job_instance_id: job_instance_id, base_64_ca_cert: base_64_ca_cert, windows_job: windows_job, logger: @logger)
     job_runner.get_job_script_and_control_repo
     job_runner.update_docker_image
     output = job_runner.run_job


### PR DESCRIPTION
Prior to this change, we defaulted to a timeout of 10 minutes when
hitting CD4PE endpoints. With this change, we instead use the env var
'HTTP_READ_TIMEOUT_SECONDS' if set, otherwise we default to 10 minutes.