### PR TITLE
CDPE-3563: Allow Docker registry its own CA cert

### DIFF
--- a/spec/run_cd4pe_job_spec.rb
+++ b/spec/run_cd4pe_job_spec.rb
@@ -184,6 +184,22 @@ describe 'run_cd4pe_job' do
         expect(File.exists?(cert_file)).to be(true)
         expect(File.read(cert_file)).to eq(cert_txt)
       end
+
+      it 'Writes the Registry CA cert when provided.' do
+        job_helper = CD4PEJobRunner.new(working_dir: @working_dir, docker_image: test_docker_image, docker_pull_creds: creds_b64, base_64_registry_ca_cert: cert_b64, job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, logger: @logger)
+
+        cert_file = File.join(@certs_dir, hostname, 'ca.crt')
+        expect(File.exists?(cert_file)).to be(true)
+        expect(File.read(cert_file)).to eq(cert_txt)
+      end
+
+      it 'Prefers the Registry CA cert when provided.' do
+        job_helper = CD4PEJobRunner.new(working_dir: @working_dir, docker_image: test_docker_image, docker_pull_creds: creds_b64, base_64_registry_ca_cert: cert_b64, base_64_ca_cert: Base64.encode64("not it"), job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, logger: @logger)
+
+        cert_file = File.join(@certs_dir, hostname, 'ca.crt')
+        expect(File.exists?(cert_file)).to be(true)
+        expect(File.read(cert_file)).to eq(cert_txt)
+      end
     end
   end
 

--- a/tasks/run_cd4pe_job.json
+++ b/tasks/run_cd4pe_job.json
@@ -35,6 +35,10 @@
       "description": "Base64-encoded docker config.json to use when pulling the specified docker image.",
       "sensitive": true
     },
+    "base_64_registry_ca_cert": {
+      "type": "Optional[String[1]]",
+      "description": "Ca cert needed to communicate with a private Docker Registry."
+    },
     "base_64_ca_cert": {
       "type": "Optional[String[1]]",
       "description": "Ca cert needed to communicate with CD4PE if ssl is enabled."


### PR DESCRIPTION
In some cases a private Docker registry may have its own CA cert, separate from CD4PE's. If a separate Docker registry CA cert is included, use that for `docker pull` instead of CD4PE's CA cert.