### PR TITLE
(CDPE-3886) Switch local registry cert from hardlink to symlink

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -243,7 +243,7 @@ class CD4PEJobRunner < Object
           FileUtils.mkdir_p(dir)
           cert = File.join(dir, 'ca.crt')
           begin
-            FileUtils.link(@ca_cert_file, cert, force: true)
+            FileUtils.ln_s(@ca_cert_file, cert, force: true)
           rescue Errno::EEXIST => e
             # FileUtils.link with force=true deletes the file before linking. That leaves a race
             # condition where two calls to FileUtils.link try to link after the file has been


### PR DESCRIPTION
Prior to this commit, if a user had a separate filesystem mounted
on their cd4pe_working_dir, an airgap installation would fail to
run jobs because it attempted to create a hardlink between that
filesystem and the ca in /etc.

With this commit, we switch the hardlink to a symlink, which allows
it to cross filesystem boundaries.

Testing:

I manually tested this on 4.2.2.  A customer also tested it on https://puppetlabs.zendesk.com/agent/tickets/41870.