### PR TITLE
(maint) Put default branch name back to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To run tests (from root of repo):
 
 ## Release puppetlabs-cd4pe_jobs
 
-1. Create a branch off `main` using the following convention:
+1. Create a branch off `master` using the following convention:
 ```shell
 git checkout -b 1.6.0-release
 ```


### PR DESCRIPTION
We realized that users might be referencing the `master` branch in their puppetfiles (and possibly other places). In order to not break anyone, we are renaming it back to `master` from `main`. This commit updates the readme accordingly.