### PR TITLE
(CDPE-7090) Leverage $LASTEXITCODE for powershell jobs

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
+      - name: install libcurl & libcurl4-openssl-dev
+        # these packages are required to build native extensions for the 'patron' gem
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4 libcurl4-openssl-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
@@ -23,6 +28,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
+      - name: install libcurl & libcurl4-openssl-dev
+        # these packages are required to build native extensions for the 'patron' gem
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4 libcurl4-openssl-dev
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/spec/run_cd4pe_job_spec.rb
+++ b/spec/run_cd4pe_job_spec.rb
@@ -246,6 +246,15 @@ describe 'cd4pe_job_helper::run_job' do
 
 
   end
+
+  it 'Fails the job if the job script fails' do
+    File.write(@job_script, "exit 1;")
+
+    job_helper = CD4PEJobRunner.new(windows_job: @windows_job, working_dir: @working_dir, job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, logger: @logger, secrets: @secrets)
+    output = job_helper.run_job
+
+    expect(output[:job][:exit_code]).to eq(1)
+  end
 end
 
 

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -409,7 +409,7 @@ class CD4PEJobRunner < Object
 
     cmd_to_execute = local_job_script
     if (@windows_job)
-      cmd_to_execute = "powershell \"& {&'#{local_job_script}'}\""
+      cmd_to_execute = "powershell \"& {&'#{local_job_script}';exit $LASTEXITCODE}\""
     end
 
     run_system_cmd(cmd_to_execute)


### PR DESCRIPTION
I don't completely understand what's going on, but somewhere in our 3-deep  powershell script execution, the exit code of the CD4PE job is getting swallowed and turned into 0 every time. This results in a lot of false positives for users running jobs on windows agents. By adding this exit statement, pdk test unit, for example, will exit 1 when tests fail now. Rejoice.