### PR TITLE
(maint) Add logging when image pull fails

### DIFF
--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -435,6 +435,10 @@ class CD4PEJobRunner < Object
       end
 
       @logger.log(result[:message])
+
+      if (result[:exit_code] != 0)
+        @logger.log("Unable to update image #{@container_image}, falling back to local image.")
+      end
     end
   end
 


### PR DESCRIPTION
This commit adds logging to indicate that we fall back to assuming a local version of the job image when pulling it from the remote fails. This should help users recognize that the pull errors are red herrings in air-gapped installs, and that the job will proceed, assuming the image has been loaded into the runtime out of band.