### PR TITLE
(maint) Make jobs task private

### DIFF
--- a/tasks/run_cd4pe_job.json
+++ b/tasks/run_cd4pe_job.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "description": "Retrieves the Puppet control repo and job script for the specified job instance id.",
   "parameters": {
     "job_instance_id": {


### PR DESCRIPTION
This ensures that the task won't be displayed in PE. Customers are not expected to run it directly; it is only triggered by CD4PE.