### PR TITLE
(PE-42665) Make run_cd4pe_job task public

### DIFF
--- a/tasks/run_cd4pe_job.json
+++ b/tasks/run_cd4pe_job.json
@@ -1,6 +1,5 @@
 {
-  "private": true,
-  "description": "Retrieves the Puppet control repo and job script for the specified job instance id.",
+  "description": "Used by Continuous Delivery pipelines to execute testing jobs on job hardware.",
   "parameters": {
     "job_instance_id": {
       "type": "String[1]",


### PR DESCRIPTION
This commit undoes a previous change that made the `run_cd4pe_job` task private. This hid the task from the PE console, which was desirable so that users would not be able to run it directly, outside of CD. However, with this change, users of PE 2025.6 were also no longer able to give the CD service account user permission to run this task, meaning that all CD jobs would fail. So until we figure out a better long-term solution, this commit makes the task public again.

This commit also updates the task description to make it more clear how it is intended to be run, and to discourage users from running it directly.