### PR TITLE
(CDPE-7451) Remove docker.io image-pull retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-No unreleased changes.
+### Changed
+- The module no longer retries a failed image pull against `docker.io`.
+  Previously, when a pull exited 125 the module would prepend `docker.io/`
+  to the image name and pull again, papering over the difference between
+  Docker (which defaults unqualified names to Docker Hub) and Podman (which
+  resolves unqualified names via `registries.conf`). That retry ignored the
+  host's registry configuration and could reach Docker Hub even when the
+  operator had deliberately excluded it. Image names are now pulled exactly
+  as given. If you rely on unqualified image names (e.g. `nginx`,
+  `myuser/myimage`) on a Podman host, add `docker.io` to
+  `unqualified-search-registries` in `registries.conf`, or use a
+  fully-qualified name.
 
 ## [1.7.3](https://github.com/puppetlabs/puppetlabs-cd4pe_jobs/tree/1.7.3)
 

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -208,7 +208,6 @@ class CD4PEJobRunner < Object
 
   def initialize(working_dir:, job_token:, web_ui_endpoint:, job_owner:, job_instance_id:, logger:, windows_job: false, base_64_ca_cert: nil, container_image: nil, container_run_args: nil, image_pull_creds: nil, secrets:)
     @logger = logger
-    @image_repo = nil
     @container_image = container_image
     @container_run_args = container_run_args.nil? ? '' : container_run_args.join(' ')
     @containerized_job = !blank?(container_image)
@@ -416,11 +415,10 @@ class CD4PEJobRunner < Object
   end
 
   def get_image_pull_cmd
-    image = @image_repo.nil? ? @container_image : "#{@image_repo}/#{@container_image}"
     if @image_pull_config.nil?
-      "#{@runtime} pull #{image}"
+      "#{@runtime} pull #{@container_image}"
     else
-      "#{@runtime} --config #{@image_pull_config} pull #{image}"
+      "#{@runtime} --config #{@image_pull_config} pull #{@container_image}"
     end
   end
 
@@ -428,11 +426,6 @@ class CD4PEJobRunner < Object
     if (@containerized_job)
       @logger.log("Updating container image: #{@container_image}")
       result = run_system_cmd(get_image_pull_cmd)
-      if (result[:exit_code] == 125)
-        @logger.log("Failed to pull using given image name. Re-try directly from docker.io.")
-        @image_repo = 'docker.io'
-        result = run_system_cmd(get_image_pull_cmd)
-      end
 
       @logger.log(result[:message])
 


### PR DESCRIPTION
## Summary

`CD4PEJobRunner#update_container_image` retried a failed image pull (exit 125) against `docker.io` by setting `@image_repo = 'docker.io'`, which prepends `docker.io/` to `@container_image` and pulls again. The retry was added in CDPE-6808 to smooth over Docker resolving unqualified names to Docker Hub while Podman resolves them via `registries.conf`.

This PR **removes the retry entirely** rather than guarding it (an earlier revision of this branch added a `fully_qualified_image_name?` guard; that approach is superseded).

## Why remove it

- **The runtime is the operator's choice.** A host runs Docker *or* Podman; injecting Docker Hub as a fallback overrides Podman's own registry resolution.
- **The retry only ever fired when it contradicted `registries.conf`.** If `docker.io` is in the host's `unqualified-search-registries`, the first pull already succeeds and the retry never runs. It did something *only* when the operator had deliberately excluded `docker.io` — in which case reaching Docker Hub anyway is a policy violation, not a convenience.
- **It duplicated a feature Podman already has,** and never meaningfully fired for Docker (which always resolves bare names to Docker Hub on the first attempt).
- **It subsumes the reported bug** (CDPE-7451): with no retry there is no bogus rewrite of an already-qualified name (`myregistry.example.com/...` → `docker.io/myregistry.example.com/...`), so the customer's fully-qualified image is pulled exactly as given.

## Change

- Delete the `exit_code == 125` retry block in `update_container_image`.
- Delete `@image_repo` (only ever set by the retry) and simplify `get_image_pull_cmd` to pull `@container_image` verbatim.
- Retain the independent "falling back to local image" log line.

## Testing

- `spec/run_cd4pe_job_spec.rb`: 17 examples, 0 failures.
- `spec/docker_spec.rb`: 5 examples, 0 failures.
- `spec/podman_spec.rb`: passes on a Podman-equipped runner (local failures are runtime-detection only, absent Podman on the dev host).

No new test is added: `update_container_image` is not unit-tested anywhere in the suite (exercising it would require triggering a real 125 from the runtime), and the observable surface — `get_image_pull_cmd` producing `<runtime> pull <image>` with no registry rewriting — is already covered by the runtime specs.

## Behavior change

Operators relying on **unqualified** image names (e.g. `nginx`, `myuser/myimage`) on a **Podman** host must add `docker.io` to `unqualified-search-registries` in `registries.conf`, or use a fully-qualified name. This is a narrow, technically-breaking case, but the task's parameter contract is unchanged and the removed retry was undocumented internal behavior — a **minor** bump is sufficient. The version number itself is left to the release-prep process.

## Out of scope

The customer's broader ask — a Kubernetes-style `imagePullPolicy` (`Always`/`IfNotPresent`/`Never`) to skip the initial pull entirely — is a separate, larger change (this task + `cd4pe_deployments::cd4pe_job` plan + `PuppetAgentJobTask.java` + a job-template UI field) and should be tracked as its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
