### PR TITLE
(CDPE-7451) Add image_pull_policy to control the pre-pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- A new optional `image_pull_policy` task parameter controls whether the
+  container image is pulled before a job runs: `Always` (the default, and the
+  previous behavior) pulls on every run; `IfNotPresent` pulls only when the
+  image is absent from the local runtime; `Never` skips the pull entirely and
+  relies on the locally present image. Presence is checked with
+  `docker image inspect` / `podman image exists`. Omitting the parameter keeps
+  the existing pull-every-run behavior.
+
 ### Changed
 - The module no longer retries a failed image pull against `docker.io`.
   Previously, when a pull exited 125 the module would prepend `docker.io/`

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -77,6 +77,48 @@ describe 'run_cd4pe_job' do
     end
   end
 
+  describe 'cd4pe_job_helper::update_container_image image_pull_policy' do
+    let(:test_container_image) { 'puppetlabs/test:10.0.1' }
+    let(:pull_cmd) { "docker pull #{test_container_image}" }
+    let(:inspect_cmd) { "docker image inspect #{test_container_image}" }
+
+    def runner(policy)
+      CD4PEJobRunner.new(windows_job: @windows_job, working_dir: @working_dir, container_image: test_container_image, image_pull_policy: policy, job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, logger: @logger, secrets: @secrets)
+    end
+
+    it 'Never skips the pull entirely.' do
+      job_helper = runner('Never')
+      expect(job_helper).not_to receive(:run_system_cmd)
+      job_helper.update_container_image
+    end
+
+    it 'IfNotPresent skips the pull when the image is present locally.' do
+      job_helper = runner('IfNotPresent')
+      allow(job_helper).to receive(:run_system_cmd).with(inspect_cmd, false).and_return({ exit_code: 0, message: '' })
+      expect(job_helper).not_to receive(:run_system_cmd).with(pull_cmd)
+      job_helper.update_container_image
+    end
+
+    it 'IfNotPresent pulls when the image is absent locally.' do
+      job_helper = runner('IfNotPresent')
+      allow(job_helper).to receive(:run_system_cmd).with(inspect_cmd, false).and_return({ exit_code: 1, message: '' })
+      expect(job_helper).to receive(:run_system_cmd).with(pull_cmd).and_return({ exit_code: 0, message: '' })
+      job_helper.update_container_image
+    end
+
+    it 'Always pulls unconditionally.' do
+      job_helper = runner('Always')
+      expect(job_helper).to receive(:run_system_cmd).with(pull_cmd).and_return({ exit_code: 0, message: '' })
+      job_helper.update_container_image
+    end
+
+    it 'defaults to Always when no policy is given.' do
+      job_helper = runner(nil)
+      expect(job_helper).to receive(:run_system_cmd).with(pull_cmd).and_return({ exit_code: 0, message: '' })
+      job_helper.update_container_image
+    end
+  end
+
   describe 'cd4pe_job_helper::get_container_run_cmd' do
     it 'Generates the correct docker run command.' do
       test_manifest_type = "AFTER_JOB_SUCCESS"

--- a/spec/podman_spec.rb
+++ b/spec/podman_spec.rb
@@ -77,6 +77,48 @@ describe 'run_cd4pe_job' do
     end
   end
 
+  describe 'cd4pe_job_helper::update_container_image image_pull_policy' do
+    let(:test_container_image) { 'puppetlabs/test:10.0.1' }
+    let(:pull_cmd) { "podman pull #{test_container_image}" }
+    let(:inspect_cmd) { "podman image exists #{test_container_image}" }
+
+    def runner(policy)
+      CD4PEJobRunner.new(windows_job: @windows_job, working_dir: @working_dir, container_image: test_container_image, image_pull_policy: policy, job_token: @job_token, web_ui_endpoint: @web_ui_endpoint, job_owner: @job_owner, job_instance_id: @job_instance_id, logger: @logger, secrets: @secrets)
+    end
+
+    it 'Never skips the pull entirely.' do
+      job_helper = runner('Never')
+      expect(job_helper).not_to receive(:run_system_cmd)
+      job_helper.update_container_image
+    end
+
+    it 'IfNotPresent skips the pull when the image is present locally.' do
+      job_helper = runner('IfNotPresent')
+      allow(job_helper).to receive(:run_system_cmd).with(inspect_cmd, false).and_return({ exit_code: 0, message: '' })
+      expect(job_helper).not_to receive(:run_system_cmd).with(pull_cmd)
+      job_helper.update_container_image
+    end
+
+    it 'IfNotPresent pulls when the image is absent locally.' do
+      job_helper = runner('IfNotPresent')
+      allow(job_helper).to receive(:run_system_cmd).with(inspect_cmd, false).and_return({ exit_code: 1, message: '' })
+      expect(job_helper).to receive(:run_system_cmd).with(pull_cmd).and_return({ exit_code: 0, message: '' })
+      job_helper.update_container_image
+    end
+
+    it 'Always pulls unconditionally.' do
+      job_helper = runner('Always')
+      expect(job_helper).to receive(:run_system_cmd).with(pull_cmd).and_return({ exit_code: 0, message: '' })
+      job_helper.update_container_image
+    end
+
+    it 'defaults to Always when no policy is given.' do
+      job_helper = runner(nil)
+      expect(job_helper).to receive(:run_system_cmd).with(pull_cmd).and_return({ exit_code: 0, message: '' })
+      job_helper.update_container_image
+    end
+  end
+
   describe 'cd4pe_job_helper::get_container_run_cmd' do
     it 'Generates the correct podman run command.' do
       test_manifest_type = "AFTER_JOB_SUCCESS"

--- a/tasks/run_cd4pe_job.json
+++ b/tasks/run_cd4pe_job.json
@@ -35,6 +35,10 @@
       "description": "Base64-encoded config.json to use when pulling the specified container image.",
       "sensitive": true
     },
+    "image_pull_policy": {
+      "type": "Optional[Enum['Always', 'IfNotPresent', 'Never']]",
+      "description": "When to pull the container image before running the job. Always (default) pulls every run; IfNotPresent pulls only when the image is absent locally; Never skips the pull. Defaults to Always when omitted."
+    },
     "base_64_ca_cert": {
       "type": "Optional[String[1]]",
       "description": "Ca cert needed to communicate with CD4PE if ssl is enabled."

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -437,7 +437,11 @@ class CD4PEJobRunner < Object
 
   def update_container_image
     return unless @containerized_job
-    return if @image_pull_policy == 'Never'
+
+    if @image_pull_policy == 'Never'
+      @logger.log("Image pull policy set to Never, skipping pull for #{@container_image}.")
+      return
+    end
 
     if @image_pull_policy == 'IfNotPresent' && image_present_locally?
       @logger.log("Image #{@container_image} already present locally; skipping pull (IfNotPresent).")
@@ -450,7 +454,11 @@ class CD4PEJobRunner < Object
     @logger.log(result[:message])
 
     if (result[:exit_code] != 0)
-      @logger.log("Unable to update image #{@container_image}, falling back to local image.")
+      if @image_pull_policy == 'IfNotPresent'
+        @logger.log("Failed to pull #{@container_image} and it is not present locally. The container run will likely fail.")
+      else
+        @logger.log("Unable to update image #{@container_image}, falling back to local image.")
+      end
     end
   end
 

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -206,10 +206,11 @@ class CD4PEJobRunner < Object
   DOCKER_CERTS = '/etc/docker/certs.d'
   PODMAN_CERTS = '/etc/containers/certs.d'
 
-  def initialize(working_dir:, job_token:, web_ui_endpoint:, job_owner:, job_instance_id:, logger:, windows_job: false, base_64_ca_cert: nil, container_image: nil, container_run_args: nil, image_pull_creds: nil, secrets:)
+  def initialize(working_dir:, job_token:, web_ui_endpoint:, job_owner:, job_instance_id:, logger:, windows_job: false, base_64_ca_cert: nil, container_image: nil, container_run_args: nil, image_pull_creds: nil, image_pull_policy: nil, secrets:)
     @logger = logger
     @container_image = container_image
     @container_run_args = container_run_args.nil? ? '' : container_run_args.join(' ')
+    @image_pull_policy = image_pull_policy.nil? ? 'Always' : image_pull_policy
     @containerized_job = !blank?(container_image)
     @windows_job = windows_job
     @runtime = get_runtime
@@ -422,16 +423,34 @@ class CD4PEJobRunner < Object
     end
   end
 
+  def get_image_inspect_cmd
+    if @runtime == 'podman'
+      "podman image exists #{@container_image}"
+    else
+      "docker image inspect #{@container_image}"
+    end
+  end
+
+  def image_present_locally?
+    run_system_cmd(get_image_inspect_cmd, false)[:exit_code] == 0
+  end
+
   def update_container_image
-    if (@containerized_job)
-      @logger.log("Updating container image: #{@container_image}")
-      result = run_system_cmd(get_image_pull_cmd)
+    return unless @containerized_job
+    return if @image_pull_policy == 'Never'
 
-      @logger.log(result[:message])
+    if @image_pull_policy == 'IfNotPresent' && image_present_locally?
+      @logger.log("Image #{@container_image} already present locally; skipping pull (IfNotPresent).")
+      return
+    end
 
-      if (result[:exit_code] != 0)
-        @logger.log("Unable to update image #{@container_image}, falling back to local image.")
-      end
+    @logger.log("Updating container image: #{@container_image}")
+    result = run_system_cmd(get_image_pull_cmd)
+
+    @logger.log(result[:message])
+
+    if (result[:exit_code] != 0)
+      @logger.log("Unable to update image #{@container_image}, falling back to local image.")
     end
   end
 
@@ -601,6 +620,7 @@ if __FILE__ == $0 # This block will only be invoked if this file is executed. Wi
     container_image = params['docker_image']
     container_run_args = params["docker_run_args"]
     image_pull_creds = params['docker_pull_creds']
+    image_pull_policy = params['image_pull_policy']
     job_instance_id = params["job_instance_id"]
     web_ui_endpoint = params['cd4pe_web_ui_endpoint']
     job_token = params['cd4pe_token']
@@ -621,6 +641,7 @@ if __FILE__ == $0 # This block will only be invoked if this file is executed. Wi
       container_image: container_image,
       container_run_args: container_run_args,
       image_pull_creds: image_pull_creds,
+      image_pull_policy: image_pull_policy,
       job_token: job_token,
       web_ui_endpoint: web_ui_endpoint,
       job_owner: job_owner,

--- a/tasks/run_cd4pe_job.rb
+++ b/tasks/run_cd4pe_job.rb
@@ -444,11 +444,11 @@ class CD4PEJobRunner < Object
     end
 
     if @image_pull_policy == 'IfNotPresent' && image_present_locally?
-      @logger.log("Image #{@container_image} already present locally; skipping pull (IfNotPresent).")
+      @logger.log("Image pull policy set to IfNotPresent and #{@container_image} already present locally; skipping pull.")
       return
     end
 
-    @logger.log("Updating container image: #{@container_image}")
+    @logger.log("Image pull policy set to #{@image_pull_policy}, pulling container image: #{@container_image}")
     result = run_system_cmd(get_image_pull_cmd)
 
     @logger.log(result[:message])


### PR DESCRIPTION
## What this PR does
Adds an `image_pull_policy` parameter (`Always` / `IfNotPresent` / `Never`) to the `run_cd4pe_job` task and makes the previously unconditional image pre-pull respect it: `Never` skips the pull, `IfNotPresent` pulls only when the image is absent locally (`docker image inspect` / `podman image exists`), and `Always` preserves today's pull-every-run behavior. The parameter is optional and defaults to `Always` when absent, so existing callers are unaffected.

## Spec
Design doc lives in the monorepo diff: `dev/specs/2026-07-15-cdpe-7451-image-pull-policy-design.md` (puppetlabs/PipelinesInfra#5221).

## Cross-repo dependency
This is the **release prerequisite** for the CDPE-7451 image-pull-policy work, which spans three repos:

- **puppetlabs-cd4pe_jobs (this PR)** — the task that accepts and enforces the policy.
- **puppetlabs-cd4pe_deployments** — threads `image_pull_policy` through the `cd4pe_job` plan (forwards it only when set): puppetlabs/puppetlabs-cd4pe_deployments#77.
- **PipelinesInfra (monorepo)** — backend + SPA that let a user pick the policy and emit it to the plan: puppetlabs/PipelinesInfra#5221.

**This module must be released (new module version consumed by the plan) before any customer selects a non-default policy.** The plan (#77) and monorepo (#5221) changes are written to be safe against a task release that predates this parameter — the plan passes `image_pull_policy` only when set, and the backend emits it only for non-default policies — so default (`Always`) jobs keep working regardless of release order.
