### PR TITLE
Mergeback 1.7.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.7.5](https://github.com/puppetlabs/puppetlabs-cd4pe_jobs/tree/1.7.5)
+
+### Added
+- Support for Puppet 9. The `puppet` requirement in `metadata.json` is now
+  `>= 7.24 < 10.0.0`.
+
 ## [1.7.4](https://github.com/puppetlabs/puppetlabs-cd4pe_jobs/tree/1.7.4)
 
 ### Added

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-cd4pe_jobs",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "author": "puppetlabs",
   "summary": "Contains Bolt task to facilitate running of CD4PE jobs.",
   "license": "proprietary",


### PR DESCRIPTION
## Summary
- Merge the 1.7.5 release branch (version bump + CHANGELOG) back into master
- 1.7.5 tagged and published to the Forge

## Test plan
- [ ] CI passes